### PR TITLE
ADD neutral-java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+work

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-VERSION=1.7
-RELEASE=2
-RPMNAME=virtual-java-$(VERSION)-$(RELEASE).noarch.rpm
+VERSION ?= 1.6.0
+RELEASE ?= 2
+PACKAGE ?= virtual-java
+RPMNAME=$(PACKAGE)-$(VERSION)-$(RELEASE).noarch.rpm
 
 .PHONY: all
 all: dist/$(RPMNAME)
@@ -13,11 +14,11 @@ clean:
 dist/$(RPMNAME): work/RPMS/noarch/$(RPMNAME) dist
 	cp work/RPMS/noarch/$(RPMNAME) dist/$(RPMNAME)
 
-work/RPMS/noarch/$(RPMNAME): work/BUILD work/RPMS/noarch work/SPECS/virtual-java.spec
-	rpmbuild -bb --define="_topdir ${PWD}/work" work/SPECS/virtual-java.spec
+work/RPMS/noarch/$(RPMNAME): work/BUILD work/RPMS/noarch work/SPECS/$(PACKAGE).spec
+	rpmbuild -bb --define="_topdir ${PWD}/work" work/SPECS/$(PACKAGE).spec
 
-work/SPECS/virtual-java.spec: work/SPECS virtual-java.spec
-	cat virtual-java.spec | sed -e s/%VERSION%/$(VERSION)/g | sed -e s/%RELEASE%/$(RELEASE)/g > work/SPECS/virtual-java.spec
+work/SPECS/$(PACKAGE).spec: work/SPECS $(PACKAGE).spec
+	cat $(PACKAGE).spec | sed -e "s/%VERSION%/$(VERSION)/g; s/%RELEASE%/$(RELEASE)/g" > work/SPECS/$(PACKAGE).spec
 
 dist:
 	if [ ! -d dist ]; then mkdir -p dist; fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ virtual-java-rpm
 Virtual package 'overlay' for Oracle JDK
 
 The official JDK package does not provide 'java' ( _Provides: java_ ).
-This package does just that + requires 'jdk' in order to work around this bug - nothing else.
+
+This repository provides 2 packages:
+
+1. `virtual-java` that ( _Provides: java_ ) + requires 'jdk' in order to work around this bug - nothing else.
+1. `neutral-java` that only ( _Provides: java_ )
 
 The official package does install _/usr/bin/java_ (as a symlink), but does not add an _alternative_ which means it cannot properly coexist with other installations. This is also remedied here.
 
@@ -17,14 +21,28 @@ In order to build this package you need _make_ and _rpmdevtools_ (rpmbuild):
 Building
 --------
     git clone https://github.com/keystep/virtual-java-rpm.git && \
-    cd virtual-java-rpm && \
+    cd virtual-java-rpm 
+
+### Building virtual-java:
+
     ./build
+
+### Building neutral-java:
+
+    ./build PACKAGE=neutral-java
 
 This should produce an RPM that can be found in _dist/_
 
 Example:
 
     virtual-java-1.7-1.noarch.rpm
+
+### Other overrides:
+
+you can override `VERSION` and `RELEASE` too. Example:
+
+    ./build PACKAGE=neutral-java VERSION=1.8.0 RELEASE=11
+
 
 Add this package to your local repo. Your applications (in my case _[tomcat](https://github.com/keystep/apache-tomcat-rpm)_) can now depend on 'java' and be satisfied with the (already) installed jdk without forcing an install of the default openjdk.
 

--- a/build
+++ b/build
@@ -3,4 +3,4 @@
 which make >/dev/null || { echo 'make not in path - yum install make'; exit 1; }
 which rpmbuild >/dev/null || { echo 'rpmbuild not in path - yum install rpmdevtools'; exit 1; }
 
-make
+make "${@}"

--- a/neutral-java.spec
+++ b/neutral-java.spec
@@ -1,0 +1,27 @@
+Name: neutral-java
+Version: %VERSION%
+Release: %RELEASE%
+Group: Development/Languages
+Summary: Virtual package providing neutralized java which does not really add any files
+License: None
+BuildArch: noarch
+Provides: java
+
+%description
+Virtual package providing neutralized java which does not really add any files
+
+%prep
+
+%build
+
+%pre
+
+%post
+
+%postun
+
+%install
+
+%files
+
+%changelog


### PR DESCRIPTION
yet another take at semi-legal situation to avoid shipping oracle's JDKs
- updated build capable to pass VERSION, RELEASE and PACKAGE
- update Makefile to process PACKAGE, VERSION, RELEASE
- added spec for netural-java - whiter than white virtual java.

Signed-off-by: Max Kovgan <maxk@devopsent.biz>